### PR TITLE
remove 'set -e' in growroot script

### DIFF
--- a/growroot/scripts/local-bottom/growroot
+++ b/growroot/scripts/local-bottom/growroot
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 PREREQS=""
 case $1 in


### PR DESCRIPTION
Error/failure handlings are accompanied with the corresponding commands in latter part of the script, the need for 'set -e' on the top is reduced.
Moreover, commands may got failed in many circumstances, for example, when no 'console=tty*' configured in kernel cmdline, 'echo' may fail. What's worse, if it happens after umount root and before mount back, the root disk could not be found when init process of initramfs ends. Consequently, kernel panic happens.

Signed-off-by: huteng.ht <huteng.ht@bytedance.com>